### PR TITLE
replace slack link by public link invitation

### DIFF
--- a/src/components/contributor/JoinUs.vue
+++ b/src/components/contributor/JoinUs.vue
@@ -18,7 +18,7 @@ import AppSection from "../shared/AppSection.vue";
           alt="GitHub logo"
         />
       </a>
-      <a href="https://green-code-initiative.slack.com/" target="_blank">
+      <a href="https://join.slack.com/t/green-code-initiative/shared_invite/zt-1soofawn4-Jos03e03VEQPWrw6yhgz7g" target="_blank">
         <img
           width="122"
           height="32"

--- a/src/components/shared/layout/AppHeader.vue
+++ b/src/components/shared/layout/AppHeader.vue
@@ -30,7 +30,7 @@ const socialItems = [
   },
   {
     label: "Rejoignez notre Slack",
-    link: "https://green-code-initiative.slack.com",
+    link: "https://join.slack.com/t/green-code-initiative/shared_invite/zt-1soofawn4-Jos03e03VEQPWrw6yhgz7g",
     icon: SlackIcon,
   },
 ];


### PR DESCRIPTION
@utarwyn : i replaced slack link by public link to give the possibility to new members to enter in our slack without any invitation.

I let you validate this PR to be sure you agree with this modification