### PR TITLE
Add GCI I/O 2025 banner

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { RouterView } from "vue-router";
+import { top as topBanner } from "@/assets/data/banners.json";
 import Banner from "@/components/shared/layout/AppBanner.vue";
 import Header from "@/components/shared/layout/AppHeader.vue";
 import Footer from "@/components/shared/layout/AppFooter.vue";
 </script>
 
 <template>
-  <Banner />
+  <Banner v-if="topBanner.enable" v-bind="topBanner" />
   <Header />
   <RouterView />
   <Footer />

--- a/src/assets/data/banners.json
+++ b/src/assets/data/banners.json
@@ -1,0 +1,15 @@
+{
+  "top": {
+    "enable": false,
+    "content": "ecoCode change de nom et devient <strong>Creendengo</strong> ! L'outil ne change pas, seul le nom évolue."
+  },
+  "event": {
+    "enable": true,
+    "title": "Green Code Initiative I/O 2025",
+    "content": "L’événement annuel à ne pas manquer pour tout savoir sur le collectif : l’équipe, les réalisations, les projets, les nouveautés.. Rendez-vous le <strong>28/02/25 de 12h à 13h en ligne</strong> !",
+    "action": {
+      "label": "Je m'inscris",
+      "link": "https://www.helloasso.com/associations/green-code-initiative/evenements/inscription-a-la-gci-i-o"
+    }
+  }
+}

--- a/src/assets/icons/megaphone.svg
+++ b/src/assets/icons/megaphone.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 11 18-5v12L3 14v-3z" fill="currentColor"/><path d="M11.6 16.8a3 3 0 1 1-5.8-1.6" stroke="currentColor"/></svg>

--- a/src/components/shared/AppEventBanner.vue
+++ b/src/components/shared/AppEventBanner.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import MegaphoneIcon from "@/assets/icons/megaphone.svg";
+
+defineProps({
+  title: { type: String, default: null },
+  content: { type: String, default: null },
+  action: { type: Object, default: null },
+});
+</script>
+
+<template>
+  <div class="banner-container" role="alert">
+    <div class="title">
+      <MegaphoneIcon width="32" height="32" class="icon" />
+      <h2>{{ title }}</h2>
+    </div>
+    <p v-html="content"></p>
+    <a type="button" :href="action.link" target="_blank">{{ action.label }}</a>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.banner-container {
+  --color-1: 91, 83, 201;
+  --color-2: 74, 83, 161;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1rem;
+  max-width: 720px;
+  border-radius: 0.5rem;
+  background: linear-gradient(
+    30deg,
+    rgb(var(--color-1)) 0%,
+    rgb(var(--color-2)) 100%
+  );
+  color: white;
+  animation: pulse 2s infinite;
+
+  .title {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+
+    .icon {
+      color: var(--color-additionnal-1);
+      transform: rotate(-15deg);
+
+      @media screen and (max-width: 768px) {
+        display: none;
+      }
+    }
+  }
+
+  * {
+    color: inherit;
+    text-align: left;
+  }
+
+  a[type="button"] {
+    align-self: flex-end;
+    color: white;
+    background: #171717;
+    border-radius: 100px;
+    padding: 0.5rem 1rem;
+    font-weight: 700;
+
+    &:hover {
+      background: #1a1a1a;
+    }
+  }
+}
+
+@keyframes pulse {
+  0% {
+    -moz-box-shadow: 0 0 0 0 rgba(var(--color-1), 0.4);
+    box-shadow: 0 0 0 0 rgba(var(--color-1), 0.4);
+  }
+  70% {
+    -moz-box-shadow: 0 0 0 10px rgba(var(--color-1), 0);
+    box-shadow: 0 0 0 10px rgba(var(--color-1), 0);
+  }
+  100% {
+    -moz-box-shadow: 0 0 0 0 rgba(var(--color-1), 0);
+    box-shadow: 0 0 0 0 rgba(var(--color-1), 0);
+  }
+}
+</style>

--- a/src/components/shared/layout/AppBanner.vue
+++ b/src/components/shared/layout/AppBanner.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
 import BadgeInfoIcon from "@/assets/icons/badge_info.svg";
+
+defineProps({
+  content: { type: String, default: null },
+});
 </script>
 
 <template>
   <div class="banner-container" role="alert">
     <BadgeInfoIcon width="24" height="24" />
-    <p>
-      ecoCode change de nom et devient <strong>Creendengo</strong> ! L'outil ne
-      change pas, seul le nom évolue.
-    </p>
+    <p v-html="content"></p>
   </div>
 </template>
 
@@ -23,6 +24,10 @@ import BadgeInfoIcon from "@/assets/icons/badge_info.svg";
   background-color: var(--color-additionnal-1);
   color: var(--color-on-surface);
   font-size: 1.05rem;
+
+  p {
+    color: inherit;
+  }
 
   svg {
     flex-shrink: 0;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { event as eventBanner } from "@/assets/data/banners.json";
 import WhiteLogo from "@/assets/img/logo_white.svg";
 import PartnerOrganizationList from "@/components/collective/PartnerOrganizationList.vue";
 import AppButton from "@/components/shared/AppButton.vue";
+import AppEventBanner from "@/components/shared/AppEventBanner.vue";
 import AppHero from "@/components/global/Hero.vue";
 import ContactForm from "@/components/home/ContactForm.vue";
 import RuleProcess from "@/components/home/RuleProcess.vue";
@@ -16,7 +18,7 @@ import AppSection from "@/components/shared/AppSection.vue";
   >
     <div class="logo-container">
       <WhiteLogo width="358" class="hero" />
-      <p class="old-name">Anciennement <strong>ecoCode</strong></p>
+      <p class="old-name">ex. <strong>ecoCode</strong></p>
     </div>
   </AppHero>
 
@@ -32,6 +34,12 @@ import AppSection from "@/components/shared/AppSection.vue";
       text="Je souhaite une intégration sur-mesure"
     />
   </div>
+
+  <AppEventBanner
+    v-if="eventBanner.enable"
+    class="event-banner-container"
+    v-bind="eventBanner"
+  />
 
   <AppSection
     title="Creedengo est une initiative qui prend racine dans la force du collectif"
@@ -142,17 +150,23 @@ import AppSection from "@/components/shared/AppSection.vue";
 
 .logo-container {
   display: flex;
+  position: relative;
   flex-direction: column;
   align-items: center;
-  gap: 1rem;
+  gap: 0.5rem;
 
   .old-name {
-    padding: 0.25rem 1rem;
+    padding: 0.25rem 0.5rem;
     border-radius: var(--radius);
-    font-size: 1.5rem;
+    font-size: 1.2rem;
     color: var(--color-white);
     background-color: rgba(0, 0, 0, 0.3);
   }
+}
+
+.event-banner-container {
+  justify-self: center;
+  margin: 2rem;
 }
 
 @media screen and (max-width: 768px) {


### PR DESCRIPTION
📣 It's time for **Green Code Initiative I/O 2025**!
📆 Save the date: **Friday 28/02/2025 at 12am**

![image](https://github.com/user-attachments/assets/9750d949-24fa-4224-b626-31ce1793a46d)

This pull request includes a new component to display future events. Both banners (one in the top of the page, and this new banner) can be dynamically changed with a single JSON file called `banners.json`. I've deactivated the top banner concerning the renaming: the information appeared long enough to avoid overloading the home page.