### PR TITLE
Add contact form to challenge page

### DIFF
--- a/src/components/challenge/ChallengeContact.vue
+++ b/src/components/challenge/ChallengeContact.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import AppButton from "@/components/shared/AppButton.vue";
+import Captcha from "@/components/shared/form/AppCaptcha.vue";
+import Textfield from "@/components/shared/form/AppTextfield.vue";
+import { post } from "@/util/fetch";
+import { extractFormData } from "@/util/form";
+import { ref } from "vue";
+
+const error = ref("");
+const success = ref("");
+
+const submitForm = async (event: Event) => {
+  const form = event.target as HTMLFormElement;
+  const formData = extractFormData(form);
+
+  try {
+    await post("challenge_contact", formData);
+    success.value = "Votre demande a bien été enregistrée";
+    form.reset();
+  } catch {
+    error.value = "Erreur d'envoi, veuillez réessayer plus tard.";
+  }
+};
+</script>
+
+<template>
+  <div class="contact">
+    <h2>Contact</h2>
+    <form @submit.prevent="submitForm" aria-label="Formulaire de contact">
+      <Textfield id="name" name="name" label="Nom" required />
+      <Textfield id="email" name="email" type="email" label="E-mail" required />
+
+      <Textfield
+        id="message"
+        type="textarea"
+        name="message"
+        label="Quelle est votre demande ?"
+        required
+      />
+
+      <div class="form-submit" style="text-align: center">
+        <div class="error-message" v-if="error" aria-live="assertive">
+          {{ error }}
+        </div>
+        <div class="success-message" v-if="success" aria-live="assertive">
+          {{ success }}
+        </div>
+
+        <AppButton
+          type="submit"
+          variant="primary"
+          text="Envoyer"
+          aria-label="Envoyer le formulaire de contact"
+        />
+      </div>
+
+      <client-only>
+        <captcha />
+      </client-only>
+    </form>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.contact {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  width: 720px;
+
+  h2 {
+    text-align: center;
+    font-size: 2rem;
+    font-weight: 800;
+  }
+
+  button {
+    justify-self: center;
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    .form-submit {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+    }
+  }
+}
+</style>

--- a/src/views/ChallengeView.vue
+++ b/src/views/ChallengeView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import ChallengeContact from "@/components/challenge/ChallengeContact.vue";
 import ChallengeGoals from "@/components/challenge/ChallengeGoals.vue";
 import ChallengeHero from "@/components/challenge/ChallengeHero.vue";
 import ChallengeHistory from "@/components/challenge/ChallengeHistory.vue";
@@ -44,14 +45,8 @@ useHead({
     <section>
       <ChallengeHistory />
     </section>
-    <section>
-      <div class="contact">
-        <h2>Contact</h2>
-        <p>
-          Pour recevoir des informations sur les challenges passées et à
-          venir,<br />vous pouvez contacter le Crédit Agricole.
-        </p>
-      </div>
+    <section class="neutral">
+      <ChallengeContact />
     </section>
   </div>
 </template>
@@ -115,18 +110,6 @@ section {
     .content {
       text-align: center;
     }
-  }
-}
-
-.contact {
-  display: flex;
-  flex-direction: column;
-  text-align: center;
-  gap: 1rem;
-
-  h2 {
-    font-size: 2rem;
-    font-weight: 800;
   }
 }
 </style>


### PR DESCRIPTION
This PR adds an interactive form to contact the dedicated organization team of the **Green Code Challenge 2025** event.
It's very basic, with fields for the name, the email address and a free message.

### Todolist

- [x] API ready to accept challenge specific messages

### How it looks

![image](https://github.com/user-attachments/assets/5df71999-be97-48ce-9091-1febb9d0fb74)

Closes #58 
